### PR TITLE
Remove a no-longer-valid criteria in honoring the response header

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The topics will be inferred by the browser. The browser will leverage a classifi
     * The request header will be sent on document requests via specifying an attribute: `<iframe src=[url] browsingtopics></iframe>`, or via the equivalent IDL attribute: `iframe.browsingTopics = true`.
     * Redirects will be followed, and the topics sent in the redirect request will be specific to the redirect url.
     * The request header will not modify state for the caller unless there is a corresponding response header. That is, the topic of the page won't be considered observed, nor will it affect the user's topic calculation for the next epoch. 
-    * The response header will only be honored if the corresponding request included the topics header (or would have included the header if it wasn't empty).
+    * The response header will only be honored if the corresponding request included the topics header (i.e. was eligible for topics).
     * The registrable domain used for topic observation is that of the url of the request.
     * Example request header: `Sec-Browsing-Topics: 123;model=1;taxonomy=1;version=2, 2;model=1;taxonomy=1;version=2`
         * This example has two topics, 123 and 2, along with their version information.


### PR DESCRIPTION
We have made the decision that when the topics are empty, we'd still send the header. The "would have included the header if it wasn't empty" is obsolete.